### PR TITLE
DEV-30397: Add Public Trade V2 POCO 

### DIFF
--- a/NPS.ID.PublicApi.Models/NPS.ID.PublicApi.Models.csproj
+++ b/NPS.ID.PublicApi.Models/NPS.ID.PublicApi.Models.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" Sdk="Microsoft.NET.Sdk">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NPS.ID.PublicApi.Models</RootNamespace>
     <AssemblyName>NPS.ID.PublicApi.Models</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -55,7 +55,6 @@
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/NPS.ID.PublicApi.Models/v2/Trade/BaseTradeRow.cs
+++ b/NPS.ID.PublicApi.Models/v2/Trade/BaseTradeRow.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Nordpool.ID.PublicApi.v1.Base;
+using Nordpool.ID.PublicApi.v1.Trade;
+
+namespace NPS.ID.PublicApi.Models.v2.Trade
+{
+    /// <summary>Class with base trade fields</summary>
+    public class BaseTradeRow : BaseRow
+    {
+        public string TradeId { get; set; }
+
+        public DateTimeOffset TradeTime { get; set; }
+
+        public TradeState? State { get; set; }
+
+        public Currency? Currency { get; set; }
+
+        public long EventSequenceNo { get; set; }
+        
+        public long RevisionNo { get; set; }
+        
+        /// <summary>A medium length display name for the contract.</summary>
+        public string MediumDisplayName { get; set; }
+        
+        public bool? SelfTrade { get; set; }
+    }
+}

--- a/NPS.ID.PublicApi.Models/v2/Trade/Leg/BaseTradeLeg.cs
+++ b/NPS.ID.PublicApi.Models/v2/Trade/Leg/BaseTradeLeg.cs
@@ -1,0 +1,19 @@
+﻿using Nordpool.ID.PublicApi.v1.Order;
+
+namespace NPS.ID.PublicApi.Models.v2.Trade.Leg
+{
+    public class BaseTradeLeg
+    {
+        public string ContractId { get; set; }
+        
+        public OrderSide? Side { get; set; }
+
+        public long UnitPrice { get; set; }
+
+        public long Quantity { get; set; }
+
+        public long DeliveryAreaId { get; set; }
+        
+        public bool Aggressor { get; set; }
+    }
+}

--- a/NPS.ID.PublicApi.Models/v2/Trade/Leg/PublicTradeLeg.cs
+++ b/NPS.ID.PublicApi.Models/v2/Trade/Leg/PublicTradeLeg.cs
@@ -1,0 +1,6 @@
+﻿namespace NPS.ID.PublicApi.Models.v2.Trade.Leg
+{
+    public class PublicTradeLeg : BaseTradeLeg
+    {
+    }
+}

--- a/NPS.ID.PublicApi.Models/v2/Trade/PublicTradeRow.cs
+++ b/NPS.ID.PublicApi.Models/v2/Trade/PublicTradeRow.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Nordpool.ID.PublicApi.v1.Trade.Leg;
+
+namespace NPS.ID.PublicApi.Models.v2.Trade
+{
+    public class PublicTradeRow : BaseTradeRow
+    {
+        /// <summary>Basic data about orders participated in the trade</summary>
+        public List<PublicTradeLeg> Legs { get; set; }
+    }
+}


### PR DESCRIPTION
- Added POCO for V2 public trade models
- Changed target framework to `netstandard2.0`

motivation for choosing `netstandard2.0` over `netstandard1.0`:
https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting
![image](https://user-images.githubusercontent.com/37310497/231467336-41989cff-6dfd-4d97-9aa8-e60f1c194152.png)
