### PR TITLE
Allow for CompanyTrade to be null

### DIFF
--- a/NPS.ID.PublicApi.Models/v1/base/BaseTradeRow.cs
+++ b/NPS.ID.PublicApi.Models/v1/base/BaseTradeRow.cs
@@ -30,7 +30,7 @@ namespace Nordpool.ID.PublicApi.v1.Base
 		public string MediumDisplayName { get; set; }
 
 		/// <summary>Trade was made within the same company.</summary>
-		public bool CompanyTrade { get; set; }
+		public bool? CompanyTrade { get; set; }
 
 	}
 }


### PR DESCRIPTION
CompanyTrade should be allowed to be null. In fact it seems like it is always null when using the rest ticker endpoint.

See
https://developers.nordpoolgroup.com/reference/rest-ticker

And note it says
   _"companyTrade": null, //not supported in this version, always null_

