### PR TITLE
Allow for ClipSize, ClipPriceChange and RemainingQuantity to be null

### DIFF
--- a/NPS.ID.PublicApi.Models/v1/order/OrderExecutionEntry.cs
+++ b/NPS.ID.PublicApi.Models/v1/order/OrderExecutionEntry.cs
@@ -63,11 +63,11 @@ namespace Nordpool.ID.PublicApi.v1.Order
 
 		public Nordpool.ID.PublicApi.v1.Order.OrderAction? Action { get; set; }
 
-		public long ClipSize { get; set; }
+		public long? ClipSize { get; set; }
 
-		public long ClipPriceChange { get; set; }
+		public long? ClipPriceChange { get; set; }
 
-		public long RemainingQuantity { get; set; }
+		public long? RemainingQuantity { get; set; }
 
 		public List<Nordpool.ID.PublicApi.v1.Order.Error.Error> Errors { get; set; }
 


### PR DESCRIPTION
The properties ClipSize, ClipPriceChange and RemainingQuantity should be allowed to be null. In fact it seems they are null in the example given in the documentation.

See
https://developers.nordpoolgroup.com/reference/rest-orderexecutionreport
