### PR TITLE
Allow ClipSize, ClipPriceChange, RemainingQuantity and ExpireTime to be null

### DIFF
--- a/NPS.ID.PublicApi.Models/v1/order/OrderExecutionEntry.cs
+++ b/NPS.ID.PublicApi.Models/v1/order/OrderExecutionEntry.cs
@@ -63,11 +63,11 @@ namespace Nordpool.ID.PublicApi.v1.Order
 
 		public Nordpool.ID.PublicApi.v1.Order.OrderAction? Action { get; set; }
 
-		public long ClipSize { get; set; }
+		public long? ClipSize { get; set; }
 
-		public long ClipPriceChange { get; set; }
+		public long? ClipPriceChange { get; set; }
 
-		public long RemainingQuantity { get; set; }
+		public long? RemainingQuantity { get; set; }
 
 		public List<Nordpool.ID.PublicApi.v1.Order.Error.Error> Errors { get; set; }
 

--- a/NPS.ID.PublicApi.Models/v2/Order/OrderExecutionEntry.cs
+++ b/NPS.ID.PublicApi.Models/v2/Order/OrderExecutionEntry.cs
@@ -54,7 +54,7 @@ namespace NPS.ID.PublicApi.Models.v2.Order
         public Nordpool.ID.PublicApi.v1.Order.TimeInForce? TimeInForce { get; set; }
 
         /// <summary>If timeInForce is set to GTD (Good Till Date), the expireTime will determine when the order expires</summary>
-        public DateTimeOffset ExpireTime { get; set; }
+        public DateTimeOffset? ExpireTime { get; set; }
 
         public string Text { get; set; }
 
@@ -62,11 +62,11 @@ namespace NPS.ID.PublicApi.Models.v2.Order
 
         public Nordpool.ID.PublicApi.v1.Order.OrderAction? Action { get; set; }
 
-        public long ClipSize { get; set; }
+        public long? ClipSize { get; set; }
 
-        public long ClipPriceChange { get; set; }
+        public long? ClipPriceChange { get; set; }
 
-        public long RemainingQuantity { get; set; }
+        public long? RemainingQuantity { get; set; }
 
         public Nordpool.ID.PublicApi.v1.Order.ExecutionRestriction? ExecutionRestriction { get; set; }
     }


### PR DESCRIPTION
The properties ClipSize, ClipPriceChange and RemainingQuantity should be allowed to be null. In fact it seems they are null in the example given in the documentation.

See
https://developers.nordpoolgroup.com/reference/rest-orderexecutionreport

This same is the case for version 2. ExpireTime is also null when testing on the test system